### PR TITLE
Added deployment section and added publish-crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 
 Various Actions helping to use all these amazing Rust crates
 
+## Deployment
+
+- [katyo/publish-crates](https://github.com/katyo/publish-crates) - Checks if this crate (or any of the crates in this workspace) can be published and publishes them.
+
 ## Dependency Management
 
 - [orf/cargo-bloat-action](https://github.com/marketplace/actions/cargo-bloat) - Analyse and track your Rust project binary size over time ![GitHub stars](https://img.shields.io/github/stars/orf/cargo-bloat-action?style=social)


### PR DESCRIPTION
Hey hey,

Love the actions-rs projects. Came across this repo and feel like it should have https://github.com/katyo/publish-crates on it. It detects if the current head has crate with a version that's less than the published one and tries to publish it. According to the README, it's got some cool features like support for workspaces and if there are multiple updates/dependencies in the workspaces it'll wait on the dependencies to be published before publishing a crate that depends on it. I'm using it with infinyon/fluvio#690 and would like highlight some cool work from @katyo. 